### PR TITLE
feat: add missing API endpoint support

### DIFF
--- a/Vanlo/Event.cs
+++ b/Vanlo/Event.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace Vanlo {
+    public class Event : Resource {
+        public string id { get; set; }
+        public string @object { get; set; }
+        public string description { get; set; }
+        public List<string> pending_urls { get; set; }
+        public List<string> completed_urls { get; set; }
+        public List<string> failed_urls { get; set; }
+        public Dictionary<string, object> result { get; set; }
+        public DateTime? created_at { get; set; }
+        public DateTime? updated_at { get; set; }
+
+        /// <summary>
+        /// Get a paginated list of events.
+        /// </summary>
+        /// Optional dictionary containing parameters to filter the list with. Valid pairs:
+        ///   * {"before_id", string} Only retrieve events created before this id.
+        ///   * {"after_id", string} Only retrieve events created after this id.
+        ///   * {"start_datetime", string} ISO 8601 datetime string. Only retrieve events created after this datetime.
+        ///   * {"end_datetime", string} ISO 8601 datetime string. Only retrieve events created before this datetime.
+        ///   * {"page_size", int} Size of page. Default to 20.
+        /// All invalid keys will be ignored.
+        /// <param name="parameters">
+        /// </param>
+        /// <returns>Instance of Vanlo.EventList</returns>
+        public static EventList List(Dictionary<string, object> parameters = null) {
+            Request request = new Request("/events");
+            request.AddQueryString(parameters ?? new Dictionary<string, object>());
+
+            EventList eventList = request.Execute<EventList>();
+            eventList.filters = parameters;
+            return eventList;
+        }
+    }
+}

--- a/Vanlo/EventList.cs
+++ b/Vanlo/EventList.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Vanlo {
+    public class EventList : Resource {
+        public List<Event> events { get; set; }
+        public bool has_more { get; set; }
+
+        public Dictionary<string, object> filters { get; set; }
+
+        /// <summary>
+        /// Get the next page of events based on the original parameters passed to Event.List().
+        /// </summary>
+        /// <returns>A new Vanlo.EventList instance.</returns>
+        public EventList Next() {
+            filters = filters ?? new Dictionary<string, object>();
+            filters["before_id"] = events.Last().id;
+
+            return Event.List(filters);
+        }
+    }
+}

--- a/Vanlo/Rate.cs
+++ b/Vanlo/Rate.cs
@@ -1,6 +1,7 @@
 ﻿using RestSharp;
 
 using System;
+using System.Collections.Generic;
 
 namespace Vanlo {
     public class Rate : Resource {
@@ -21,5 +22,27 @@ namespace Vanlo {
         public string carrier { get; set; }
         public string shipment_id { get; set; }
         public string carrier_account_id { get; set; }
+
+        /// <summary>
+        /// Create standalone rates for the given parameters.
+        /// </summary>
+        /// <param name="parameters">
+        /// Dictionary containing parameters to generate rates with. Valid pairs:
+        ///   * {"from_address", Dictionary&lt;string, object&gt;} Origin address.
+        ///   * {"to_address", Dictionary&lt;string, object&gt;} Destination address.
+        ///   * {"parcel", Dictionary&lt;string, object&gt;} Parcel details.
+        /// </param>
+        /// <returns>List of Vanlo.Rate instances.</returns>
+        public static List<Rate> Create(Dictionary<string, object> parameters) {
+            Request request = new Request("/rate", Method.POST);
+            request.AddBody(parameters);
+
+            RateListResponse response = request.Execute<RateListResponse>();
+            return response.rates;
+        }
+
+        private class RateListResponse : Resource {
+            public List<Rate> rates { get; set; }
+        }
     }
 }

--- a/Vanlo/Report.cs
+++ b/Vanlo/Report.cs
@@ -1,0 +1,73 @@
+using RestSharp;
+
+using System;
+using System.Collections.Generic;
+
+namespace Vanlo {
+    public class Report : Resource {
+        public string id { get; set; }
+        public string @object { get; set; }
+        public DateTime? created_at { get; set; }
+        public DateTime? updated_at { get; set; }
+        public string start_date { get; set; }
+        public string end_date { get; set; }
+        public string status { get; set; }
+        public string url { get; set; }
+        public DateTime? url_expires_at { get; set; }
+
+        /// <summary>
+        /// Create a Report of the given type.
+        /// </summary>
+        /// <param name="parameters">
+        /// Dictionary containing parameters to create the report with. Valid pairs:
+        ///   * {"type", string} The type of report to create (e.g. "shipment", "tracker", "payment_log").
+        ///   * {"start_date", string} Start date for the report.
+        ///   * {"end_date", string} End date for the report.
+        /// </param>
+        /// <returns>Vanlo.Report instance.</returns>
+        public static Report Create(Dictionary<string, object> parameters) {
+            string type = (string)parameters["type"];
+
+            Request request = new Request("/reports/" + type, Method.POST);
+            request.AddBody(parameters);
+
+            return request.Execute<Report>();
+        }
+
+        /// <summary>
+        /// Retrieve a Report from its id.
+        /// </summary>
+        /// <param name="id">String representing a Report ID.</param>
+        /// <returns>Vanlo.Report instance.</returns>
+        public static Report Retrieve(string id) {
+            Request request = new Request("/reports/{id}");
+            request.AddUrlSegment("id", id);
+
+            return request.Execute<Report>();
+        }
+
+        /// <summary>
+        /// Get a paginated list of reports of the given type.
+        /// </summary>
+        /// <param name="parameters">
+        /// Dictionary containing parameters to filter the list with. Valid pairs:
+        ///   * {"type", string} The type of report to list (e.g. "shipment", "tracker", "payment_log").
+        ///   * {"before_id", string} Only retrieve reports created before this id.
+        ///   * {"after_id", string} Only retrieve reports created after this id.
+        ///   * {"page_size", int} Size of page. Default to 20.
+        /// </param>
+        /// <returns>Instance of Vanlo.ReportList</returns>
+        public static ReportList List(Dictionary<string, object> parameters) {
+            string type = (string)parameters["type"];
+            Dictionary<string, object> query = new Dictionary<string, object>(parameters);
+            query.Remove("type");
+
+            Request request = new Request("/reports/" + type);
+            request.AddQueryString(query);
+
+            ReportList reportList = request.Execute<ReportList>();
+            reportList.filters = parameters;
+            return reportList;
+        }
+    }
+}

--- a/Vanlo/ReportList.cs
+++ b/Vanlo/ReportList.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Vanlo {
+    public class ReportList : Resource {
+        public List<Report> reports { get; set; }
+        public bool has_more { get; set; }
+
+        public Dictionary<string, object> filters { get; set; }
+
+        /// <summary>
+        /// Get the next page of reports based on the original parameters passed to Report.List().
+        /// </summary>
+        /// <returns>A new Vanlo.ReportList instance.</returns>
+        public ReportList Next() {
+            filters = filters ?? new Dictionary<string, object>();
+            filters["before_id"] = reports.Last().id;
+
+            return Report.List(filters);
+        }
+    }
+}

--- a/Vanlo/ScanForm.cs
+++ b/Vanlo/ScanForm.cs
@@ -65,5 +65,17 @@ namespace Vanlo {
 
             return request.Execute<ScanForm>();
         }
+
+        /// <summary>
+        /// Create scan forms for all shipments that have not yet been associated with a scan form.
+        /// </summary>
+        /// <param name="parameters">Optional dictionary containing parameters for the request.</param>
+        /// <returns>Vanlo.ScanForm instance.</returns>
+        public static ScanForm CreateAll(Dictionary<string, object> parameters = null) {
+            Request request = new Request("/scan_forms/all", Method.POST);
+            request.AddBody(parameters ?? new Dictionary<string, object>());
+
+            return request.Execute<ScanForm>();
+        }
     }
 }

--- a/Vanlo/Shipment.cs
+++ b/Vanlo/Shipment.cs
@@ -192,6 +192,24 @@ namespace Vanlo {
             return result.OrderBy(rate => double.Parse(rate.rate)).FirstOrDefault();
         }
 
+        /// <summary>
+        /// Submit a dispute adjustment for this shipment.
+        /// </summary>
+        /// <param name="reason">The reason for the dispute adjustment.</param>
+        /// <param name="expectedRate">Optional expected rate for the adjustment.</param>
+        public void DisputeAdjustment(string reason, string expectedRate = null) {
+            Request request = new Request("/shipments/{id}/dispute_adjustment", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            Dictionary<string, object> body = new Dictionary<string, object>() { { "reason", reason } };
+            if (expectedRate != null)
+                body["expected_rate"] = expectedRate;
+
+            request.AddBody(body);
+
+            Merge(request.Execute<Shipment>());
+        }
+
         private void filterRates(ref List<Rate> rates, Func<Rate, bool> filter) {
             rates = rates.Where(filter).ToList();
         }

--- a/vanlo-csharp.csproj
+++ b/vanlo-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 		<PackageId>Vanlo-Official</PackageId>
-		<Version>1.0.1</Version>
+		<Version>1.1.0</Version>
 		<Authors>Vanlo</Authors>
 		<Company>Vanlo</Company>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Add Report resource (Create, Retrieve, List) with custom URL pattern for report types
- Add ReportList for paginated report listing
- Add Event resource (List only)
- Add EventList for paginated event listing
- Add Shipment.DisputeAdjustment() instance method
- Add ScanForm.CreateAll() static method
- Add Rate.Create() static method for standalone rate quotes

## Test plan
- [ ] Verify Report.Create() sends POST to /reports/:type
- [ ] Verify Report.List() sends GET to /reports/:type
- [ ] Verify Report.Retrieve() sends GET to /reports/:id
- [ ] Verify Event.List() sends GET to /events
- [ ] Verify Shipment.DisputeAdjustment() sends POST to /shipments/:id/dispute_adjustment
- [ ] Verify ScanForm.CreateAll() sends POST to /scan_forms/all
- [ ] Verify Rate.Create() sends POST to /rate